### PR TITLE
change java version release to 8

### DIFF
--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -278,14 +278,14 @@ function(lcmtypes_build_java)
     foreach(javafile ${_lcmtypes_java_files})
         string(REPLACE .java .class __tmp_class_fname ${javafile})
         #        add_custom_command(OUTPUT ${__tmp_class_fname} COMMAND
-        #            ${JAVA_COMPILE} -source 6 -cp ${_lcmtypes_java_dir}:${lcm_jar} ${javafile} VERBATIM DEPENDS ${javafile})
+        #            ${JAVA_COMPILE} -source 8 -cp ${_lcmtypes_java_dir}:${lcm_jar} ${javafile} VERBATIM DEPENDS ${javafile})
         list(APPEND _lcmtypes_class_files ${__tmp_class_fname})
         unset(__tmp_class_fname)
     endforeach()
 
     # add a rule to build the .class files from from the .java files
     add_custom_command(OUTPUT ${_lcmtypes_class_files} COMMAND
-        ${JAVA_COMPILE} -source 6 -target 6 -cp ${java_classpath} ${_lcmtypes_java_files}
+        ${JAVA_COMPILE} -source 8 -target 8 -cp ${java_classpath} ${_lcmtypes_java_files}
         DEPENDS ${_lcmtypes_java_files} VERBATIM)
 
     # add a rule to build a .jar file from the .class files


### PR DESCRIPTION
Hello,

When building on ubuntu 24.04 cmake aborts on following error,

```warning: [options] bootstrap class path not set in conjunction with -source 6
error: Source option 6 is no longer supported. Use 8 or later.
```

updating to version 8 does not seem to break functionality. successfully built on ubuntu arm 24.04 and tested sheriff and deputy comms.
